### PR TITLE
Continue on error if one is thrown

### DIFF
--- a/src/Blt/Plugin/Commands/ToggleModulesCommand.php
+++ b/src/Blt/Plugin/Commands/ToggleModulesCommand.php
@@ -42,7 +42,7 @@ class ToggleModulesCommand extends BltTasks {
       // Uninstall modules.
       $disable_key = "modules.$environment.uninstall";
       $this->doToggleModules('pm-uninstall', $disable_key);
-    } 
+    }
     else {
       $this->say("Environment is unset. Skipping drupal:toggle:modules...");
     }

--- a/src/Blt/Plugin/Commands/ToggleModulesCommand.php
+++ b/src/Blt/Plugin/Commands/ToggleModulesCommand.php
@@ -42,8 +42,8 @@ class ToggleModulesCommand extends BltTasks {
       // Uninstall modules.
       $disable_key = "modules.$environment.uninstall";
       $this->doToggleModules('pm-uninstall', $disable_key);
-
-    } else {
+    } 
+    else {
       $this->say("Environment is unset. Skipping drupal:toggle:modules...");
     }
   }

--- a/src/Blt/Plugin/Commands/ToggleModulesCommand.php
+++ b/src/Blt/Plugin/Commands/ToggleModulesCommand.php
@@ -7,6 +7,7 @@ use Acquia\Blt\Robo\BltTasks;
 use Acquia\Blt\Robo\Common\UserConfig;
 use Acquia\Blt\Robo\Common\YamlMunge;
 use Acquia\Blt\Robo\Exceptions\BltException;
+use Robo\ResultData;
 use Zumba\Amplitude\Amplitude;
 
 /**
@@ -41,8 +42,8 @@ class ToggleModulesCommand extends BltTasks {
       // Uninstall modules.
       $disable_key = "modules.$environment.uninstall";
       $this->doToggleModules('pm-uninstall', $disable_key);
-    }
-    else {
+
+    } else {
       $this->say("Environment is unset. Skipping drupal:toggle:modules...");
     }
   }
@@ -81,7 +82,8 @@ class ToggleModulesCommand extends BltTasks {
     }
 
     if ($exit_code) {
-      throw new BltException("Could not toggle modules listed in $config_key.");
+      $this->say("There was a problem toggling modules listed in $config_key. You may want to check the outcome manually.");
+      return new ResultData(0);
     }
   }
 


### PR DESCRIPTION
Drush's new `11.4.0` release (12/14/2022) includes a breaking change to the `pm:uninstall` command.  It throws an exception if you ask it to uninstall a module which isn't currently installed.

This broke our CI/CD pipeline, because that exception got passed along and output as part of the `drupal:toggle:modules` command, which subsequently caused all our builds to fail.

In this PR, I've set up the `drupal:toggle:modules` command to acknowledge the error, but to continue with a status `0` so that in case of an error being thrown by drush, it won't break the rest of the build process.

See also: 
- https://github.com/drush-ops/drush/pull/5293
- https://github.com/drush-ops/drush/issues/5340#issuecomment-1353545483